### PR TITLE
fix condition of dependency on colcon-bash

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ keywords = colcon
 [options]
 install_requires =
     colcon-argcomplete; sys_platform != 'win32'
-    colcon-bash; sys_platform == 'win32'
+    colcon-bash; sys_platform != 'win32'
     colcon-cmake
     colcon-core
     colcon-defaults


### PR DESCRIPTION
The dependency on `colcon-bash` is only valid on non-Windows platforms.