### PR TITLE
add No-Python2 flag to stdeb.cfg to avoid making Python 2 releases by accident

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,4 +1,5 @@
 [colcon-common-extensions]
+No-Python2:
 Depends3: python3-colcon-argcomplete, python3-colcon-bash, python3-colcon-cmake, python3-colcon-core, python3-colcon-defaults, python3-colcon-devtools, python3-colcon-library-path, python3-colcon-metadata, python3-colcon-notification, python3-colcon-output, python3-colcon-package-information, python3-colcon-package-selection, python3-colcon-parallel-executor, python3-colcon-powershell, python3-colcon-python-setup-py, python3-colcon-recursive-crawl, python3-colcon-ros, python3-colcon-test-result, python3-colcon-zsh
 Suite: xenial bionic stretch buster
 X-Python3-Version: >= 3.5


### PR DESCRIPTION
Same as colcon/colcon-core#165.