### PR TITLE
Add colcon-override-check as a recommended dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,3 +48,7 @@ install_requires =
     colcon-zsh; sys_platform != 'win32'
 packages = find:
 zip_safe = true
+
+[options.extras_require]
+recommended =
+    colcon-override-check

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,5 +1,6 @@
 [colcon-common-extensions]
 No-Python2:
 Depends3: python3-colcon-argcomplete, python3-colcon-bash, python3-colcon-cd, python3-colcon-cmake, python3-colcon-core, python3-colcon-defaults, python3-colcon-devtools, python3-colcon-library-path, python3-colcon-metadata, python3-colcon-notification, python3-colcon-output, python3-colcon-package-information, python3-colcon-package-selection, python3-colcon-parallel-executor, python3-colcon-powershell, python3-colcon-python-setup-py, python3-colcon-recursive-crawl, python3-colcon-ros, python3-colcon-test-result, python3-colcon-zsh
+Recommends3: python3-colcon-override-check
 Suite: bionic focal jammy stretch buster bullseye
 X-Python3-Version: >= 3.5


### PR DESCRIPTION
The intent of this change is that a typical installation of colcon from debs would result in installation of the colcon-override-check extension, but that specifically excluding or uninstalling that package won't result in colcon-common-extensions' dependencies being unmet.