### PR TITLE
Update deb platforms for release

### DIFF
--- a/publish-python.yaml
+++ b/publish-python.yaml
@@ -10,5 +10,6 @@ artifacts:
           distributions:
             - ubuntu:focal
             - ubuntu:jammy
-            - debian:bullseye
+            - ubuntu:noble
             - debian:bookworm
+            - debian:trixie

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -2,5 +2,5 @@
 No-Python2:
 Depends3: python3-colcon-argcomplete, python3-colcon-bash, python3-colcon-cd, python3-colcon-cmake, python3-colcon-core, python3-colcon-defaults, python3-colcon-devtools, python3-colcon-library-path, python3-colcon-metadata, python3-colcon-notification, python3-colcon-output, python3-colcon-package-information, python3-colcon-package-selection, python3-colcon-parallel-executor, python3-colcon-powershell, python3-colcon-python-setup-py, python3-colcon-recursive-crawl, python3-colcon-ros, python3-colcon-test-result, python3-colcon-zsh
 Recommends3: python3-colcon-override-check
-Suite: focal jammy bullseye bookworm
+Suite: focal jammy noble bookworm trixie
 X-Python3-Version: >= 3.6


### PR DESCRIPTION
Added:
* Ubuntu Noble (24.04 LTS pre-release)
* Debian Trixie (testing)

Dropped:
* Debian Bullseye (oldstable)

Retained:
* Debian Bookworm (stable)
* Ubuntu Focal (20.04 LTS)
* Ubuntu Jammy (22.04 LTS)